### PR TITLE
Add audio transcription and TTS demo

### DIFF
--- a/KH.Services/Speech/SpeechHub/SpeechHub.cs
+++ b/KH.Services/Speech/SpeechHub/SpeechHub.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace KH.Services.Speech.SpeechHub;
+
+public class SpeechHub : Hub
+{
+}

--- a/KH.WebApi/Controllers/SpeechController.cs
+++ b/KH.WebApi/Controllers/SpeechController.cs
@@ -1,0 +1,76 @@
+using KH.BuildingBlocks.Apis.Extentions;
+using KH.Services.Speech.SpeechHub;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http.Headers;
+
+namespace KH.WebApi.Controllers;
+
+public class SpeechController : BaseApiController
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly IHubContext<SpeechHub> _hubContext;
+
+    public SpeechController(IHttpClientFactory httpClientFactory, IConfiguration configuration, IHubContext<SpeechHub> hubContext)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+        _hubContext = hubContext;
+    }
+
+    [HttpPost("upload")]
+    public async Task<IActionResult> UploadAudio(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return BadRequest();
+
+        using var ms = new MemoryStream();
+        await file.CopyToAsync(ms);
+        ms.Position = 0;
+
+        var transcript = await SendToWhisperAsync(ms);
+        await _hubContext.Clients.All.SendAsync("TranscriptionResult", transcript);
+
+        var audioUrl = await SendToTtsAsync(string.Join(" ", transcript.Values));
+        await _hubContext.Clients.All.SendAsync("TtsReady", audioUrl);
+        return Ok();
+    }
+
+    private async Task<Dictionary<string, string>> SendToWhisperAsync(Stream audio)
+    {
+        var apiKey = _configuration["OpenAI:ApiKey"];
+        var client = _httpClientFactory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        using var content = new MultipartFormDataContent();
+        content.Add(new StreamContent(audio), "file", "audio.webm");
+        content.Add(new StringContent("whisper-1"), "model");
+        var response = await client.PostAsync("https://api.openai.com/v1/audio/transcriptions", content);
+        var result = await response.Content.ReadAsStringAsync();
+        // expected result { "text": "..." }
+        var text = System.Text.Json.JsonDocument.Parse(result).RootElement.GetProperty("text").GetString();
+        // naive mapping for street city state zip separated by commas
+        var parts = text?.Split(',') ?? Array.Empty<string>();
+        var dict = new Dictionary<string, string>();
+        if (parts.Length > 0) dict["street"] = parts[0].Trim();
+        if (parts.Length > 1) dict["city"] = parts[1].Trim();
+        if (parts.Length > 2) dict["state"] = parts[2].Trim();
+        if (parts.Length > 3) dict["zip"] = parts[3].Trim();
+        return dict;
+    }
+
+    private async Task<string> SendToTtsAsync(string text)
+    {
+        var apiKey = _configuration["OpenAI:ApiKey"];
+        var client = _httpClientFactory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        var content = new StringContent(System.Text.Json.JsonSerializer.Serialize(new { input = text, model = "tts-1" }), System.Text.Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("https://api.openai.com/v1/audio/speech", content);
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        var fileName = Path.GetRandomFileName() + ".mp3";
+        var path = Path.Combine("wwwroot", fileName);
+        await System.IO.File.WriteAllBytesAsync(path, bytes);
+        return $"/" + fileName;
+    }
+}

--- a/KH.WebApi/Program.cs
+++ b/KH.WebApi/Program.cs
@@ -1,5 +1,6 @@
 using KH.Services.Chat.ChatHub;
 using KH.Services.Lookups.Roles.RoleHub;
+using KH.Services.Speech.SpeechHub;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.RateLimiting;
 using QuestPDF.Fluent;
@@ -199,6 +200,7 @@ void ConfigureMiddlewares(WebApplication app)
   app.UseAuthorization();
   app.MapHub<RolesHub>("/signalrhub");
   app.MapHub<ChatHub>("/signalrChatHub");
+  app.MapHub<SpeechHub>("/signalrSpeechHub");
 
   // Serve static files and map controllers
   app.UseStaticFiles();

--- a/KH.WebApi/appsettings.json
+++ b/KH.WebApi/appsettings.json
@@ -115,4 +115,8 @@
       }
     }
   }
+  ,
+  "OpenAI": {
+    "ApiKey": "YOUR_API_KEY"
+  }
 }

--- a/KH.WebClient/package.json
+++ b/KH.WebClient/package.json
@@ -24,6 +24,7 @@
     "bootstrap": "^5.3.2",
     "jest-editor-support": "*",
     "ng-zorro-antd": "^16.0.0",
+    "@microsoft/signalr": "^7.0.14",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"

--- a/KH.WebClient/src/app/pages/pages-routing.module.ts
+++ b/KH.WebClient/src/app/pages/pages-routing.module.ts
@@ -11,6 +11,10 @@ const routes: Routes = [{
       loadChildren: () => import('./welcome/welcome.module').then(m => m.WelcomeModule),
     },
     {
+      path: 'voice-address',
+      loadChildren: () => import('./voice-address/voice-address.module').then(m => m.VoiceAddressModule)
+    },
+    {
       path: '',
       redirectTo: 'welcome',
       pathMatch: 'full',

--- a/KH.WebClient/src/app/pages/voice-address/voice-address.component.css
+++ b/KH.WebClient/src/app/pages/voice-address/voice-address.component.css
@@ -1,0 +1,8 @@
+.address-form {
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+}
+.address-form div {
+  margin-bottom: 8px;
+}

--- a/KH.WebClient/src/app/pages/voice-address/voice-address.component.html
+++ b/KH.WebClient/src/app/pages/voice-address/voice-address.component.html
@@ -1,0 +1,20 @@
+<form [formGroup]="addressForm" class="address-form">
+  <div>
+    <label>Street:</label>
+    <input formControlName="street" />
+  </div>
+  <div>
+    <label>City:</label>
+    <input formControlName="city" />
+  </div>
+  <div>
+    <label>State:</label>
+    <input formControlName="state" />
+  </div>
+  <div>
+    <label>Zip:</label>
+    <input formControlName="zip" />
+  </div>
+</form>
+<button (click)="record()">Record Address</button>
+<audio *ngIf="audioUrl" [src]="audioUrl" controls></audio>

--- a/KH.WebClient/src/app/pages/voice-address/voice-address.component.ts
+++ b/KH.WebClient/src/app/pages/voice-address/voice-address.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
+
+@Component({
+  selector: 'app-voice-address',
+  templateUrl: './voice-address.component.html',
+  styleUrls: ['./voice-address.component.css']
+})
+export class VoiceAddressComponent implements OnInit {
+  addressForm!: FormGroup;
+  private hubConnection?: HubConnection;
+  audioUrl: string | null = null;
+  mediaRecorder?: MediaRecorder;
+  chunks: Blob[] = [];
+
+  constructor(private fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.addressForm = this.fb.group({
+      street: ['', Validators.required],
+      city: ['', Validators.required],
+      state: ['', Validators.required],
+      zip: ['', Validators.required]
+    });
+    this.setupSignalR();
+  }
+
+  setupSignalR() {
+    this.hubConnection = new HubConnectionBuilder()
+      .withUrl('/signalrSpeechHub')
+      .withAutomaticReconnect()
+      .build();
+
+    this.hubConnection.start().catch(err => console.error(err));
+
+    this.hubConnection.on('TranscriptionResult', data => {
+      this.addressForm.patchValue(data);
+    });
+
+    this.hubConnection.on('TtsReady', url => {
+      this.audioUrl = url;
+      const audio = new Audio(url);
+      audio.play();
+    });
+  }
+
+  record() {
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+      this.chunks = [];
+      this.mediaRecorder = new MediaRecorder(stream);
+      this.mediaRecorder.ondataavailable = e => this.chunks.push(e.data);
+      this.mediaRecorder.onstop = () => {
+        const blob = new Blob(this.chunks, { type: 'audio/webm' });
+        const formData = new FormData();
+        formData.append('file', blob, 'recording.webm');
+        fetch('/api/speech/upload', { method: 'POST', body: formData });
+      };
+      this.mediaRecorder.start();
+      setTimeout(() => this.mediaRecorder?.stop(), 5000);
+    });
+  }
+}

--- a/KH.WebClient/src/app/pages/voice-address/voice-address.module.ts
+++ b/KH.WebClient/src/app/pages/voice-address/voice-address.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { VoiceAddressComponent } from './voice-address.component';
+
+const routes: Routes = [
+  { path: '', component: VoiceAddressComponent }
+];
+
+@NgModule({
+  declarations: [VoiceAddressComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule.forChild(routes)
+  ]
+})
+export class VoiceAddressModule {}


### PR DESCRIPTION
## Summary
- integrate `@microsoft/signalr` in web client
- add voice address component with MediaRecorder and SignalR connectivity
- route new `voice-address` page
- create `SpeechHub` and a controller for Whisper STT and TTS
- expose speech hub in Web API configuration
- include OpenAI API key placeholder

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846225649c8832a9f97656ad3ceecf5